### PR TITLE
bugfix, dumping partial buffer

### DIFF
--- a/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/filedumper/PcapNgFilePacketDumper.kt
+++ b/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/filedumper/PcapNgFilePacketDumper.kt
@@ -49,12 +49,15 @@ class PcapNgFilePacketDumper(
         addresses: Boolean,
         etherType: EtherType?,
     ) {
+        val startingPosition = buffer.position()
+        val originalLimit = buffer.limit()
         // optionally prepend the ethernet dummy header
         val conversionBuffer =
             if (etherType != null) {
                 prependDummyHeader(buffer, offset, length, etherType)
             } else {
-                buffer
+                val actualLimit = minOf(originalLimit, offset + length)
+                buffer.limit(actualLimit)
             }
 
         if (isSimple) {
@@ -67,5 +70,7 @@ class PcapNgFilePacketDumper(
             outputStreamWriter.write(packetBlock.toBytes())
             outputStreamWriter.flush()
         }
+        buffer.position(startingPosition)
+        buffer.limit(originalLimit)
     }
 }

--- a/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/serverdumper/PcapNgTcpServerPacketDumper.kt
+++ b/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/serverdumper/PcapNgTcpServerPacketDumper.kt
@@ -133,11 +133,14 @@ class PcapNgTcpServerPacketDumper(
             // if there are no connected clients, no reason to dump
             return
         }
+        val startingPosition = buffer.position()
+        val originalLimit = buffer.limit()
         val conversionBuffer =
             if (etherType != null) {
                 prependDummyHeader(buffer, offset, length, etherType)
             } else {
-                buffer
+                val actualLimit = minOf(originalLimit, offset + length)
+                buffer.limit(actualLimit)
             }
         val packetBlock =
             if (isSimple) {
@@ -146,6 +149,8 @@ class PcapNgTcpServerPacketDumper(
                 // todo: timestamp
                 PcapNgEnhancedPacketBlock(conversionBuffer.array())
             }
+        buffer.position(startingPosition)
+        buffer.limit(originalLimit)
 
         with(connectionQueue.iterator()) {
             forEach {

--- a/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/stringdumper/StringPacketDumper.kt
+++ b/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/stringdumper/StringPacketDumper.kt
@@ -71,12 +71,14 @@ class StringPacketDumper(
         etherType: EtherType? = null,
     ): String {
         val startingPosition = buffer.position()
+        val originalLimit = buffer.limit()
         // optionally prepend the ethernet dummy header
         val conversionBuffer =
             if (etherType != null) {
                 prependDummyHeader(buffer, offset, length, etherType)
             } else {
-                buffer
+                val actualLimit = minOf(originalLimit, offset + length)
+                buffer.limit(actualLimit)
             }
 
         var totalLength = 0
@@ -103,6 +105,7 @@ class StringPacketDumper(
             }
         }
         buffer.position(startingPosition)
+        buffer.limit(originalLimit)
         return output.toString()
     }
 }

--- a/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/filedumper/TestTextFilePacketDumper.kt
+++ b/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/filedumper/TestTextFilePacketDumper.kt
@@ -28,10 +28,12 @@ class TestTextFilePacketDumper {
         buffer: ByteBuffer,
         addresses: Boolean = false,
         etherType: EtherType? = null,
+        offset: Int = 0,
+        length: Int = buffer.limit(),
     ): ByteBuffer {
         val stringDumper = StringPacketDumper()
         logger.debug("write buffer: ${stringDumper.dumpBufferToString(buffer, 0, buffer.limit())}")
-        dumper.dumpBuffer(buffer, 0, buffer.limit(), addresses, etherType)
+        dumper.dumpBuffer(buffer, offset, length, addresses, etherType)
         dumper.close()
         return TextFilePacketDumper.parseFile(dumper.filename, addresses, etherType)
     }
@@ -99,6 +101,14 @@ class TestTextFilePacketDumper {
         dumper.open()
         val buffer = ByteBuffer.wrap(byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08))
         val readBuffer = writeReadBuffer(buffer, addresses = true, etherType = EtherType.IPv4)
+        assertEquals(buffer, readBuffer)
+    }
+
+    @Test fun shorterDumpThanLimit() {
+        dumper.open()
+        val buffer = ByteBuffer.wrap(byteArrayOf(0x00, 0x01, 0x02, 0x03, 0x04))
+        val readBuffer = writeReadBuffer(buffer, addresses = true, etherType = EtherType.IPv4, 0, buffer.limit() - 2)
+        buffer.limit(buffer.limit() - 2) // this will effectively remove the last two bytes
         assertEquals(buffer, readBuffer)
     }
 

--- a/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/stringdumper/TestStringPacketDumper.kt
+++ b/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/stringdumper/TestStringPacketDumper.kt
@@ -669,4 +669,10 @@ class TestStringPacketDumper {
         val hexString = stringPacketDumper.dumpBufferToString(buffer, 0, buffer.limit(), true, EtherType.IPv4)
         assertEquals("00000000  14 C0 3E 55 0B 35 74 D0 2B 29 A5 18 08 00 00 01\n00000010  02 03 04", hexString)
     }
+
+    @Test fun shorterDumpThanLimit() {
+        val buffer = ByteBuffer.wrap(byteArrayOf(0x00, 0x01, 0x02, 0x03, 0x04))
+        val hexString = stringPacketDumper.dumpBufferToString(buffer, 0, buffer.limit() - 2, false)
+        assertEquals("00 01 02", hexString)
+    }
 }


### PR DESCRIPTION
Found that if we try to an amount of bytes lower than the limit, and we dont have an eth header prepended, we will dump up to the limit anyway.

This patch will fix that, and adds tests for it.

Also added some code to preserve the original limit and position better.