### PR TITLE
Minor fixes

### DIFF
--- a/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/ethernet/EthernetHeader.kt
+++ b/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/ethernet/EthernetHeader.kt
@@ -65,8 +65,11 @@ class EthernetHeader(
          * ethertype, it will just leave the type as 0xFFFF (detect) which maps to RESERVED in the
          * actual mapping.
          */
-        fun getEtherTypeFromIPVersionByte(ipVersion: UByte): EtherType =
-            when (ipVersion) {
+        fun getEtherTypeFromIPVersionByte(ipVersion: UByte): EtherType {
+            // in both ipv4 and ipv6, the version portion of the byte is actually the high 4 bits of
+            // the byte, so we need to zero out the bottom half and shift it right 4 bits
+            val shiftedVersion = ((ipVersion and 0xF0.toUByte()).toUInt() shr 4).toUByte()
+            return when (shiftedVersion) {
                 IP4_VERSION -> EtherType.IPv4
                 IP6_VERSION -> EtherType.IPv6
                 else -> {
@@ -74,6 +77,7 @@ class EthernetHeader(
                     EtherType.DETECT
                 }
             }
+        }
 
         fun dummyEthernet(etherType: EtherType): EthernetHeader =
             EthernetHeader(MacAddress.DUMMY_MAC_SOURCE, MacAddress.DUMMY_MAC_DEST, etherType)

--- a/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/stringdumper/StringPacketDumper.kt
+++ b/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/stringdumper/StringPacketDumper.kt
@@ -66,7 +66,7 @@ class StringPacketDumper(
     fun dumpBufferToString(
         buffer: ByteBuffer,
         offset: Int = 0,
-        length: Int = 0,
+        length: Int = buffer.remaining(),
         addresses: Boolean = false,
         etherType: EtherType? = null,
     ): String {

--- a/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/ethernet/TestEthernetHeader.kt
+++ b/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/ethernet/TestEthernetHeader.kt
@@ -15,12 +15,14 @@ class TestEthernetHeader {
 
     @Test fun etherTypeDetection() {
         val ipv4Buffer = ByteBuffer.allocate(1)
-        ipv4Buffer.put(0, EthernetHeader.IP4_VERSION.toByte())
+        // need to shift left because its the high 4 bits of the byte that contain the version
+        ipv4Buffer.put(0, (EthernetHeader.IP4_VERSION.toUInt() shl 4).toByte())
         ipv4Buffer.rewind()
         assertEquals(EtherType.IPv4, EthernetHeader.getEtherTypeFromIPVersionByte(ipv4Buffer.get().toUByte()))
 
         val ipv6Buffer = ByteBuffer.allocate(1)
-        ipv6Buffer.put(0, EthernetHeader.IP6_VERSION.toByte())
+        // need to shift left because its the high 4 bits of the byte that contain the version
+        ipv6Buffer.put(0, (EthernetHeader.IP6_VERSION.toUInt() shl 4).toByte())
         ipv6Buffer.rewind()
         assertEquals(EtherType.IPv6, EthernetHeader.getEtherTypeFromIPVersionByte(ipv6Buffer.get().toUByte()))
 

--- a/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/stringdumper/TestStringPacketDumper.kt
+++ b/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/stringdumper/TestStringPacketDumper.kt
@@ -1,7 +1,6 @@
 package com.jasonernst.packetdumper.stringdumper
 
 import com.jasonernst.packetdumper.ethernet.EtherType
-import com.jasonernst.packetdumper.ethernet.EthernetHeader
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer

--- a/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/stringdumper/TestStringPacketDumper.kt
+++ b/packetdumper/src/test/kotlin/com/jasonernst/packetdumper/stringdumper/TestStringPacketDumper.kt
@@ -1,6 +1,7 @@
 package com.jasonernst.packetdumper.stringdumper
 
 import com.jasonernst.packetdumper.ethernet.EtherType
+import com.jasonernst.packetdumper.ethernet.EthernetHeader
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
@@ -674,5 +675,15 @@ class TestStringPacketDumper {
         val buffer = ByteBuffer.wrap(byteArrayOf(0x00, 0x01, 0x02, 0x03, 0x04))
         val hexString = stringPacketDumper.dumpBufferToString(buffer, 0, buffer.limit() - 2, false)
         assertEquals("00 01 02", hexString)
+    }
+
+    @Test fun testTypeDetection() {
+        val bufferipv4 = ByteBuffer.wrap(byteArrayOf(0x45, 0x01, 0x02))
+        val hexStringv4 = stringPacketDumper.dumpBufferToString(bufferipv4, etherType = EtherType.DETECT)
+        assertEquals("14 C0 3E 55 0B 35 74 D0 2B 29 A5 18 08 00 45 01\n02", hexStringv4)
+
+        val bufferipv6 = ByteBuffer.wrap(byteArrayOf(0x60, 0x01, 0x02))
+        val hexStringv6 = stringPacketDumper.dumpBufferToString(bufferipv6, etherType = EtherType.DETECT)
+        assertEquals("14 C0 3E 55 0B 35 74 D0 2B 29 A5 18 86 DD 60 01\n02", hexStringv6)
     }
 }


### PR DESCRIPTION
Fixed ipv4 and ipv6 version byte detection. It uses the high four bits of the version byte.

Also updated the default length from zero to remaining for string dumper