### PR TITLE
fix a trailing space issue

### DIFF
--- a/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/filedumper/TextFilePacketDumper.kt
+++ b/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/filedumper/TextFilePacketDumper.kt
@@ -46,7 +46,9 @@ class TextFilePacketDumper(
             }
             return
         }
-        val output = stringDumper.dumpBufferToString(buffer, offset, length, addresses, etherType)
+        // extra space added so that the hexdump import doesn't skip the last byte, see:
+        // https://osqa-ask.wireshark.org/questions/39177/wireshark-import-hex-dump-always-strip-last-byte-of-the-packet/
+        val output = stringDumper.dumpBufferToString(buffer, offset, length, addresses, etherType) + " "
         file.writeText(output)
     }
 

--- a/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/filedumper/TextFilePacketDumper.kt
+++ b/packetdumper/src/main/kotlin/com/jasonernst/packetdumper/filedumper/TextFilePacketDumper.kt
@@ -65,8 +65,8 @@ class TextFilePacketDumper(
         ): ByteBuffer {
             val stringDumper = StringPacketDumper()
             val file = File(filename)
-            var text = file.readText()
-            logger.debug("raw text: $text")
+            var text = file.readText().trimEnd() // handle the last space added in dumpBuffer
+            logger.debug("raw text: '$text'")
 
             if (addresses) {
                 val lines = text.split("\n")


### PR DESCRIPTION
Found this annoying bug when dumping icmp packets: https://osqa-ask.wireshark.org/questions/39177/wireshark-import-hex-dump-always-strip-last-byte-of-the-packet/

So made sure that the textfiles always write a trailing space.